### PR TITLE
Disable process timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         }
     ],
     "scripts": {
-        "start": "php -S localhost:${PORT:-8080}"
+        "start": [
+            "Composer\\Config::disableProcessTimeout",
+            "php -S localhost:${PORT:-8080}"
+        ]
     }
 }


### PR DESCRIPTION
This is the error I try to fix:

```
The following exception is caused by a process timeout
Check https://getcomposer.org/doc/06-config.md#process-timeout for details

In Process.php line 1204:
                                                                                     
  The process "php -S localhost:${PORT:-8080}" exceeded the timeout of 300 seconds.  
                                                                                     

run-script [--timeout TIMEOUT] [--dev] [--no-dev] [-l|--list] [--] [<script> [<args>...]]


```

The solution is suggested by composer at https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands